### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/dmandola0725/bb341138-c57b-404a-b5cb-757d52189bae/56ba4765-faf5-47e1-9c06-728230cc9270/_apis/work/boardbadge/7c4de843-c1a6-4a07-9b25-ed03057c480a)](https://dev.azure.com/dmandola0725/bb341138-c57b-404a-b5cb-757d52189bae/_boards/board/t/56ba4765-faf5-47e1-9c06-728230cc9270/Microsoft.RequirementCategory)
 # Tic Tac Toe Game
 
 Learn GitHub Actions through a fun little game.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.